### PR TITLE
[2024/12/20] FIX/#29 데이터 Create 시 발생하는 Error 수정

### DIFF
--- a/Att/Att/Data/Manager/CoreDataManager.swift
+++ b/Att/Att/Data/Manager/CoreDataManager.swift
@@ -12,28 +12,31 @@ final class CoreDataManager {
     
     static let shared = CoreDataManager()
     
-    lazy var persistentContainer: NSPersistentCloudKitContainer = {
-        let container = NSPersistentCloudKitContainer(name: "Att")
-        container.loadPersistentStores(completionHandler: { (_, error) in
+    private var persistentContainer: NSPersistentCloudKitContainer!
+    
+    private init() {
+        initializePersistentContainer()
+    }
+    
+    private func initializePersistentContainer() {
+        persistentContainer = NSPersistentCloudKitContainer(name: "Att")
+        
+        persistentContainer.loadPersistentStores { _, error in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-        })
-        return container
-    }()
-    
-    private lazy var context = persistentContainer.viewContext
-    
-    private init() { }
+        }
+    }
     
     func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+        persistentContainer.viewContext.performAndWait {
+            if self.persistentContainer.viewContext.hasChanges {
+                do {
+                    try self.persistentContainer.viewContext.save()
+                } catch {
+                    let nserror = error as NSError
+                    print("SAVE NON COMPLETE: \(nserror)")
+                }
             }
         }
     }
@@ -43,8 +46,8 @@ final class CoreDataManager {
 extension CoreDataManager {
     // MARK: C
     func createDailyRecord(dailyRecord: AttDailyRecord) {
+        let context = persistentContainer.viewContext
         guard let dailyRecordEntity = NSEntityDescription.insertNewObject(forEntityName: "DailyRecord", into: context) as? DailyRecord else { return }
-        guard let musicThumbnailData = dailyRecord.musicInfo?.thumbnailImage?.jpegData(compressionQuality: 0.0) else { return }
         
         dailyRecordEntity.setValue(dailyRecord.date, forKey: "date")
         dailyRecordEntity.setValue(UUID(), forKey: "id")
@@ -52,22 +55,25 @@ extension CoreDataManager {
         dailyRecordEntity.setValue(dailyRecord.diary, forKey: "diary")
         dailyRecordEntity.setValue(dailyRecord.phraseToTomorrow, forKey: "phraseToTomorrow")
         
-        if let existedMusicEntity = isMusicExist(title: dailyRecord.musicInfo?.title, artist: dailyRecord.musicInfo?.artist) {
+        guard let musicInfo = dailyRecord.musicInfo else { return }
+        
+        if let existedMusicEntity = isMusicExist(title: musicInfo.title, artist: musicInfo.artist) {
             existedMusicEntity.addToDailyRecord(dailyRecordEntity)
         } else {
             guard let musicEntity = NSEntityDescription.insertNewObject(forEntityName: "Music", into: context) as? Music else { return }
-            musicEntity.setValue(dailyRecord.musicInfo?.title, forKey: "title")
-            musicEntity.setValue(dailyRecord.musicInfo?.artist, forKey: "artist")
+            guard let musicThumbnailData = musicInfo.thumbnailImage?.jpegData(compressionQuality: 0.0) else { return }
+            musicEntity.setValue(musicInfo.id, forKey: "id")
+            musicEntity.setValue(musicInfo.title, forKey: "title")
+            musicEntity.setValue(musicInfo.artist, forKey: "artist")
             musicEntity.setValue(musicThumbnailData, forKey: "thumbnail")
-            
             musicEntity.addToDailyRecord(dailyRecordEntity)
         }
-        
         saveContext()
     }
     
     // MARK: R
     func fetchDailyRecords(startDate: Date, endDate: Date) -> [AttDailyRecord]? {
+        let context = persistentContainer.viewContext
         let predicate = NSPredicate(format: "(date >= %@) AND (date <= %@)", startDate as NSDate, endDate as NSDate)
         
         let fetchRequest: NSFetchRequest<DailyRecord> = DailyRecord.fetchRequest()
@@ -75,6 +81,7 @@ extension CoreDataManager {
         
         do {
             let filteredData = try context.fetch(fetchRequest)
+            
             let dailyRecord = filteredData.compactMap { $0.mapToModel() }
             
             return filteredData.compactMap { $0.mapToModel() }
@@ -86,6 +93,7 @@ extension CoreDataManager {
     
     // MARK: U
     func updateDailyRecord(dailyRecord: AttDailyRecord) {
+        let context = persistentContainer.viewContext
         let targetDate = dailyRecord.date
         
         let fetchRequest: NSFetchRequest<DailyRecord> = DailyRecord.fetchRequest()
@@ -106,6 +114,7 @@ extension CoreDataManager {
     
     // MARK: D
     func deleteDailyRecord(dailyRecord: AttDailyRecord) {
+        let context = persistentContainer.viewContext
         let targetDate = dailyRecord.date
         
         let fetchRequest: NSFetchRequest<DailyRecord> = DailyRecord.fetchRequest()
@@ -125,6 +134,7 @@ extension CoreDataManager {
     }
     
     func isMusicExist(title: String?, artist: String?) -> Music? {
+        let context = persistentContainer.viewContext
         guard let title = title,
               let artist = artist else { return nil }
         let fetchRequest: NSFetchRequest<Music> = Music.fetchRequest()
@@ -146,6 +156,7 @@ extension CoreDataManager {
 // MARK: TEST SET
 extension CoreDataManager {
     func deleteAllDailyRecord() {
+        let context = persistentContainer.viewContext
         let fetchRequest: NSFetchRequest<DailyRecord> = DailyRecord.fetchRequest()
         
         do {
@@ -162,6 +173,7 @@ extension CoreDataManager {
     }
     
     func fetchAllDailyRecords() -> [AttDailyRecord]? {
+        let context = persistentContainer.viewContext
         let fetchRequest: NSFetchRequest<DailyRecord> = DailyRecord.fetchRequest()
         
         do {
@@ -174,11 +186,11 @@ extension CoreDataManager {
     }
     
     func fetchAllMusicRecords() {
+        let context = persistentContainer.viewContext
         let fetchRequest: NSFetchRequest<Music> = Music.fetchRequest()
         
         do {
             let data = try context.fetch(fetchRequest)
-            print(data)
         } catch {
             print("데이터를 가져올 때 오류 발생: \(error.localizedDescription)")
         }


### PR DESCRIPTION
### One line Description
- CoreDataManager에서 Create 작업 후 saveContext 시 발생하는 에러 수정

### Work Detail(Optional)
에러 진단 결과, 실제로 `attempt to insert nil with userInfo (null)`에러의 원인은 `musicInfo` 및 `saveContext()`의 비동기 처리 관련 코드부에서 발생하던 에러로 확인됨.
**`if let` 구문 수행 시 발생**

|`createDailyRecord()`|
|:---:|

**기존 코드**
```swift
if let existedMusicEntity = isMusicExist(title: dailyRecord.musicInfo?.title, artist: dailyRecord.musicInfo?.artist) {
            existedMusicEntity.addToDailyRecord(dailyRecordEntity)
        } else {
            // 생략
        }
        saveContext()
    }

func isMusicExist(title: String?, artist: String?) -> Music? {
        let context = persistentContainer.viewContext
        guard let title = title,
              let artist = artist else { return nil } // !!! 여기서 nil이 반환되는 경우 addToDailyRecord(nil)로 인해 발생하는 문제
        let fetchRequest: NSFetchRequest<Music> = Music.fetchRequest()
        fetchRequest.predicate = NSPredicate(format: "(title == %@) AND (artist == %@)", title, artist)
        
        do {
            let results = try context.fetch(fetchRequest)
            
            if let musicEntity = results.first {
                return musicEntity
            }
        } catch {
            print("데이터 검색 또는 저장 오류: \(error.localizedDescription)")
        }
        return nil
    }

```

**변경 코드**
```swift
if let existedMusicEntity = isMusicExist(title: musicInfo.title, artist: musicInfo.artist) {
            existedMusicEntity.addToDailyRecord(dailyRecordEntity)
        } else {
            guard let musicEntity = NSEntityDescription.insertNewObject(forEntityName: "Music", into: context) as? Music else { return }
            // 생략
        }
        saveContext()
```
- `dailyRecord.musicInfo`가 nil인 경우에도 여전히 isMusicExist가 호출되어 `return nil`을 시켜 발생하는 문제
-> 따라서 `dailyRecord.musicInfo`를 1차적으로 guard let을 통해 명확한 값으로 추출 후 isMusicExist를 호출하는 형태로 수정
---

|`saveContext()`|
|:---:|

**기존 코드**
```swift
let context = persistentContainer.viewContext
if context.hasChanges {
    do {
        try context.save()
    } catch {
        let nserror = error as NSError
        fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
    }
}
```

**변경 코드**
```swift
persistentContainer.viewContext.performAndWait {
    if self.persistentContainer.viewContext.hasChanges {
        do {
            try self.persistentContainer.viewContext.save()
        } catch {
            let nserror = error as NSError
            print("SAVE NON COMPLETE: \(nserror)")
        }
// ...

```
- 기존, 에러 발생 시 `fatalError`로 앱을 강제 종료시키는 코드를 에러 로그를 출력하는 형태로 변경
- 메인 큐에서 동작하는 viewContext에서 직접 `save`를 호출하지 않고, `performAndWait`를 통해 스레드 안정성을 보장하도록 변경하여 메인 큐가 아닌 곳에서도 save가 가능하게 변경
- `perform`이 아닌 `performAndWait`를 통해 데이터 CRUD 작업 이후에 UI가 갱신될 수 있도록 보장하는 형태

### Issue
- #29 
- Close #29 
