### PR TITLE
[2025/08/29] FIX/#35 일일 기록 작성 후 확인뷰 UI 변경

### DIFF
--- a/Att/Att/Design/Sources/Views/GradientFadeView.swift
+++ b/Att/Att/Design/Sources/Views/GradientFadeView.swift
@@ -1,0 +1,45 @@
+//
+//  GradientFadeView.swift
+//  Att
+//
+//  Created by 황정현 on 8/29/25.
+//
+
+import UIKit
+
+final class GradientFadeView: UIView {
+    override class var layerClass: AnyClass { CAGradientLayer.self }
+    
+    private var gradientLayer: CAGradientLayer? {
+        return layer as? CAGradientLayer
+    }
+    
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        configure()
+        
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (_ view: GradientFadeView, _ previous: UITraitCollection) in
+                view.configure()
+            }
+        }
+    }
+    
+    private func configure() {
+        let base = UIColor.white
+        
+        gradientLayer?.colors = [
+            base.withAlphaComponent(1.0).cgColor,
+            base.withAlphaComponent(0.85).cgColor,
+            base.withAlphaComponent(0.35).cgColor,
+            base.withAlphaComponent(0.0).cgColor
+        ]
+        
+        gradientLayer?.locations  = [0.0, 0.35, 0.72, 1.0]
+        gradientLayer?.startPoint = CGPoint(x: 0.5, y: 1.0)
+        gradientLayer?.endPoint   = CGPoint(x: 0.5, y: 0.0)
+        gradientLayer?.frame = bounds
+        
+        self.isUserInteractionEnabled = false
+    }
+}

--- a/Att/Att/Screens/RecordBrowse/RecordBrowseViewController.swift
+++ b/Att/Att/Screens/RecordBrowse/RecordBrowseViewController.swift
@@ -78,6 +78,8 @@ final class RecordBrowseViewController: UIViewController {
         return view
     }()
     
+    private lazy var bottomFadeView = GradientFadeView()
+    
     private lazy var confirmButton: NextButton = {
         let button = NextButton(title: "확인")
         return button
@@ -112,7 +114,6 @@ final class RecordBrowseViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configure()
-        bind()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -133,7 +134,6 @@ final class RecordBrowseViewController: UIViewController {
         view.addSubview(scrollView)
         scrollView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             make.leading.equalTo(view.safeAreaLayoutGuide.snp.leading)
             make.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing)
         }
@@ -207,21 +207,38 @@ final class RecordBrowseViewController: UIViewController {
         toTomorrowView.snp.makeConstraints { make in
             make.top.equalTo(diaryView.snp.bottom).offset(constraints.space22)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(60)
+            make.bottom.equalTo(contentView.snp.bottom)
         }
         
         switch recordBrowseMode {
         case .read:
             toTomorrowView.snp.makeConstraints { make in
-                make.bottom.equalTo(contentView.snp.bottom)
+                make.height.equalTo(60)
+            }
+            
+            scrollView.snp.makeConstraints { make in
+                make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             }
         case .create:
-            contentView.addSubview(confirmButton)
+            toTomorrowView.snp.makeConstraints { make in
+                make.height.equalTo(80)
+            }
+            
+            [confirmButton, bottomFadeView].forEach { view.addSubview($0) }
             confirmButton.snp.makeConstraints { make in
-                make.top.equalTo(toTomorrowView.snp.bottom).offset(constraints.space22)
-                make.leading.trailing.equalToSuperview().inset(constraints.space20)
+                make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
                 make.height.equalTo(48)
-                make.bottom.equalTo(contentView.snp.bottom).inset(constraints.space22)
+                make.bottom.equalTo(view.safeAreaLayoutGuide)
+            }
+            
+            bottomFadeView.snp.makeConstraints { make in
+                make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+                make.bottom.equalTo(confirmButton.snp.top)
+                make.height.equalTo(24)
+            }
+            
+            scrollView.snp.makeConstraints { make in
+                make.bottom.equalTo(confirmButton.snp.top)
             }
         case .none:
             break

--- a/Att/Att/Screens/RecordBrowse/Views/ToTomorrowView.swift
+++ b/Att/Att/Screens/RecordBrowse/Views/ToTomorrowView.swift
@@ -34,7 +34,7 @@ final class ToTomorrowView: RecordBrowseOuterTitleDefaultView {
         contentLabel.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(constraints.space12)
             make.leading.trailing.equalToSuperview().inset(constraints.space20)
-            make.bottom.equalToSuperview()
+            make.bottom.lessThanOrEqualToSuperview()
         }
         contentLabel.sizeToFit()
     }


### PR DESCRIPTION
### One line Description
- 일일 기록 작성 후 확인 뷰 확인 버튼 Floating 버튼으로 수정

### Work Detail(Optional)
- 기존 코드의 경우, Scroll 영역의 최하단에 확인 버튼이 있어, 스크롤을 하지 않으면 버튼의 일부가 하단 safeArea에 가려짐
- 확인 버튼을 ScrollView의 contentView가 아닌, UIViewController의 view의 subView로 붙여 화면 하단에 floating 상태로 있게 개선

|변경 전|변경 후|
|:---:|:---:|
|![PR36_Image1](https://github.com/user-attachments/assets/202f4ede-4528-4a55-ade0-cf261f3f8bdb)|![](https://github.com/user-attachments/assets/3098649a-69fc-41ef-902c-ac761d6f50b7)|

### Issue
- #35 
- Close #35 
